### PR TITLE
Fixed destroy method which assumed get method was async

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -126,18 +126,21 @@ class SessionStore extends Store {
 	 * @param  {string} sid Session ID
 	 * @param  {Function} callback Callback function (err,sessions)
 	 */
-	async destroy(sid, callback) {
+	destroy(sid, callback) {
 		callback = callback || vfn;
 		debug('====> DESTROY', sid);
-
-		try {
-			let doc = await this.get(sid);
+		await this.get(sid, (err, sessionDoc) => {
+			if(err){
+				callback(err);
+			}
 			delete this.sessions[sid];
-			await this.pouch.remove(doc);
-			callback();
-		}catch(err) {
-			callback(err);
-		}
+			this.pouch.remove(sessionDoc)
+			.then(() => {
+				callback();
+				}).catch((err) => {
+					callback(err);
+				});
+		});
 	}
 
 	/**

--- a/lib/store.js
+++ b/lib/store.js
@@ -129,7 +129,7 @@ class SessionStore extends Store {
 	destroy(sid, callback) {
 		callback = callback || vfn;
 		debug('====> DESTROY', sid);
-		await this.get(sid, (err, sessionDoc) => {
+		this.get(sid, (err, sessionDoc) => {
 			if(err){
 				callback(err);
 			}


### PR DESCRIPTION
Get method cannot be awaited as it never uses return and still uses callbacks. This can be seen in the touch method too. We need to use the callback instead of awaiting for a return value.